### PR TITLE
Zip up the output folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ build:
   verbosity: minimal
   
 artifacts:
-  - path: Unity-Technologies-networking/Output/**/*
+  - path: Unity-Technologies-networking/Output
 
 image: Visual Studio 2017
 


### PR DESCRIPTION
Zip the output folder, so that users can easily download and install the builds from appveyor.