### PR TITLE
Separate dirtiness and network channel

### DIFF
--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -524,16 +524,11 @@ namespace UnityEngine.Networking
             m_SyncVarDirtyBits = 0L;
         }
 
-        internal int GetDirtyChannel()
+        internal bool IsDirty()
         {
-            if (Time.time - m_LastSendTime > GetNetworkSendInterval())
-            {
-                if (m_SyncVarDirtyBits != 0L)
-                {
-                    return GetNetworkChannel();
-                }
-            }
-            return -1;
+            return 
+                (Time.time - m_LastSendTime > GetNetworkSendInterval()) 
+                && m_SyncVarDirtyBits != 0L;
         }
 
         public virtual bool OnSerialize(NetworkWriter writer, bool initialState)

--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -460,9 +460,9 @@ namespace UnityEngine.Networking
             {
                 // is this component dirty on this channel?
                 // -> always serialize if initialState so all components with all channels are included in spawn packet
-                // -> note: GetDirtyChannel() is -1 if the component isn't dirty or sendInterval isn't elapsed yet
+                // -> note: IsDirty() is false if the component isn't dirty or sendInterval isn't elapsed yet
                 NetworkBehaviour comp = m_NetworkBehaviours[i];
-                if (initialState || comp.GetDirtyChannel() == channelId)
+                if (initialState || (comp.IsDirty() && comp.GetNetworkChannel() == channelId))
                 {
                     // set bit #i to 1 in dirty mask
                     dirtyComponentsMask |= (ulong)(1L << i);


### PR DESCRIPTION
`GetDirtyChannel`  is a combination of 2 features:  dirtiness and network channel.
These 2 features are independent of each other.  Combining them in a single method violates the [Single Responsibility principle](https://en.wikipedia.org/wiki/Single_responsibility_principle)

This makes the code easier to read.  Channels are not dirty,  so `GetDirtyChannel` makes no sense.
Note `GetDirtyChannel` was internal so it is not used outside HLAPI.
This also avoids magic numbers "-1".    In general, if you have to explain it in a comment,  it is probably bad code.