### PR TITLE
Simplify onSerialize generation

### DIFF
--- a/Unity-Technologies-networking/Weaver/UNetBehaviourProcessor.cs
+++ b/Unity-Technologies-networking/Weaver/UNetBehaviourProcessor.cs
@@ -641,6 +641,11 @@ namespace Unity.UNetWeaver
             // Note the disassembler may simplify this in just a return statement
             serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // base
             serWorker.Append(serWorker.Create(OpCodes.Call, Weaver.NetworkBehaviourDirtyBitsReference));
+
+            // this produces the & 7ul part.  The reason for this, is that there
+            // may be more variables in parent or child classes. 
+            // we mask the dirty bits to ensure we are only checking the
+            // dirty variables in this class.
             serWorker.Append(serWorker.Create(OpCodes.Ldc_I8, dirtyMask)); // 8 bytes = long
             serWorker.Append(serWorker.Create(OpCodes.And));
             serWorker.Append(serWorker.Create(OpCodes.Stloc_0)); //dirtylocal


### PR DESCRIPTION
Simplify the generated OnSerialize.  Code is 100% equivalent.

I split the work in 2 commits:  one that does the actual change,  and another that adds a bunch of comments to make it easier to understand what is being generated.

Here is an example class:
```
public class SampleBehavior : NetworkBehaviour
{

    [SyncVar]
    public int intData;
    [SyncVar]
    public string strData;

    public SyncListInt intsynclist = new SyncListInt();
}
```

Here is what was generated before:

```
public override bool OnSerialize(NetworkWriter writer, bool forceAll)
{
    if (forceAll)
    {
        writer.WritePackedUInt32((uint)this.intData);
        writer.Write(this.strData);
        SyncListInt.WriteInstance(writer, this.intsynclist);
        return true;
    }
    bool flag = false;
    if ((base.get_syncVarDirtyBits() & 1uL) != 0uL)
    {
        if (!flag)
        {
            writer.WritePackedUInt64(base.get_syncVarDirtyBits());
            flag = true;
        }
        writer.WritePackedUInt32((uint)this.intData);
    }
    if ((base.get_syncVarDirtyBits() & 2uL) != 0uL)
    {
        if (!flag)
        {
            writer.WritePackedUInt64(base.get_syncVarDirtyBits());
            flag = true;
        }
        writer.Write(this.strData);
    }
    if ((base.get_syncVarDirtyBits() & 4uL) != 0uL)
    {
        if (!flag)
        {
            writer.WritePackedUInt64(base.get_syncVarDirtyBits());
            flag = true;
        }
        SyncListInt.WriteInstance(writer, this.intsynclist);
    }
    if (!flag)
    {
        writer.WritePackedUInt64(base.get_syncVarDirtyBits());
    }
    return flag;
}
```

Here is what is generated after:

```
public override bool OnSerialize(NetworkWriter writer, bool forceAll)
{
    if (forceAll)
    {
        writer.WritePackedUInt32((uint)this.intData);
        writer.Write(this.strData);
        SyncListInt.WriteInstance(writer, this.intsynclist);
        return true;
    }
    writer.WritePackedUInt64(base.get_syncVarDirtyBits());
    if ((base.get_syncVarDirtyBits() & 1uL) != 0uL)
    {
        writer.WritePackedUInt32((uint)this.intData);
    }
    if ((base.get_syncVarDirtyBits() & 2uL) != 0uL)
    {
        writer.Write(this.strData);
    }
    if ((base.get_syncVarDirtyBits() & 4uL) != 0uL)
    {
        SyncListInt.WriteInstance(writer, this.intsynclist);
    }
    return (base.get_syncVarDirtyBits() & 7uL) != 0uL;
}
```


Here is another example input class:
```
public class SampleBehavior2 : SampleBehavior
{

    [SyncVar]
    public float myFloat;

}
```

Here is what was generated before:

```
public override bool OnSerialize(NetworkWriter writer, bool forceAll)
{
    bool flag = base.OnSerialize(writer, forceAll);
    if (forceAll)
    {
        writer.Write(this.myFloat);
        return true;
    }
    bool flag2 = false;
    if ((base.get_syncVarDirtyBits() & 8uL) != 0uL)
    {
        if (!flag2)
        {
            writer.WritePackedUInt64(base.get_syncVarDirtyBits());
            flag2 = true;
        }
        writer.Write(this.myFloat);
    }
    if (!flag2)
    {
        writer.WritePackedUInt64(base.get_syncVarDirtyBits());
    }
    return flag2 | flag;
}
```

Here is what is generated after:

```
public override bool OnSerialize(NetworkWriter writer, bool forceAll)
{
    bool flag = base.OnSerialize(writer, forceAll);
    if (forceAll)
    {
        writer.Write(this.myFloat);
        return true;
    }
    writer.WritePackedUInt64(base.get_syncVarDirtyBits());
    if ((base.get_syncVarDirtyBits() & 8uL) != 0uL)
    {
        writer.Write(this.myFloat);
    }
    bool flag2 = (base.get_syncVarDirtyBits() & 8uL) != 0uL;
    return flag2 | flag;
}
```