### PR TITLE
Synctoowner

### DIFF
--- a/Unity-Technologies-networking/Runtime/CustomAttributes.cs
+++ b/Unity-Technologies-networking/Runtime/CustomAttributes.cs
@@ -11,10 +11,14 @@ namespace UnityEngine.Networking
         public float sendInterval = 0.1f;
     }
 
+    // SyncTarget enum is cleaner than 'bool onlyToOwner and allows for more options if needed
+    public enum SyncTarget {Observers, Owner};
+
     [AttributeUsage(AttributeTargets.Field)]
     public class SyncVarAttribute : Attribute
     {
         public string hook;
+        public SyncTarget target = SyncTarget.Observers; // for 'only sync to owner' support
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -25,7 +25,7 @@ namespace UnityEngine.Networking
         public NetworkConnection connectionToServer { get { return myView.connectionToServer; } }
         public NetworkConnection connectionToClient { get { return myView.connectionToClient; } }
         public short playerControllerId { get { return myView.playerControllerId; } }
-        protected ulong syncVarDirtyBits { get { return m_SyncVarDirtyBits; } }
+        public ulong syncVarDirtyBits { get { return m_SyncVarDirtyBits; } set { m_SyncVarDirtyBits = value; } }
         protected bool syncVarHookGuard { get { return m_SyncVarGuard; } set { m_SyncVarGuard = value; }}
         // determine which variables are SyncToOwner
         // to get dirty owners, we do syncVarDirtyBits & syncVarOwnerMask
@@ -546,6 +546,11 @@ namespace UnityEngine.Networking
         {
             m_LastSendTime = Time.time;
             m_SyncVarDirtyBits = 0L;
+        }
+
+        public void ClearOwnerDirtyBits()
+        {
+            m_SyncVarDirtyBits = m_SyncVarDirtyBits & (~syncVarOwnerMask);
         }
 
         public void SetAllDirtyBits()

--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -27,6 +27,10 @@ namespace UnityEngine.Networking
         public short playerControllerId { get { return myView.playerControllerId; } }
         protected ulong syncVarDirtyBits { get { return m_SyncVarDirtyBits; } }
         protected bool syncVarHookGuard { get { return m_SyncVarGuard; } set { m_SyncVarGuard = value; }}
+        // determine which variables are SyncToOwner
+        // to get dirty owners, we do syncVarDirtyBits & syncVarOwnerMask
+        // by default it is 0 because none of the variables are synctowoner
+        protected virtual ulong syncVarOwnerMask { get { return 0; } }
 
         internal NetworkIdentity netIdentity { get { return myView; } }
 

--- a/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkBehaviour.cs
@@ -548,6 +548,12 @@ namespace UnityEngine.Networking
             m_SyncVarDirtyBits = 0L;
         }
 
+        public void SetAllDirtyBits()
+        {
+            m_LastSendTime = float.MinValue;
+            m_SyncVarDirtyBits = ~0uL;
+        }
+
         internal bool IsDirty()
         {
             return

--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -495,6 +495,7 @@ namespace UnityEngine.Networking
                 // if it is initializing,  channel does not matter,  they all go to reliable channel
                 // otherwise,  only send the component if we are looking at the right channel.
                 // note that if we are spawning,  we expect all varibles to be dirty
+                // except for the owner bits if we are talking about observers
                 if (comp.IsDirty() && (comp.GetNetworkChannel() == channelId || initialState))
                 {
                     // set bit #i to 1 in dirty mask

--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -492,7 +492,10 @@ namespace UnityEngine.Networking
                     comp.ClearOwnerDirtyBits();
                 }
 
-                if (comp.IsDirty() && comp.GetNetworkChannel() == channelId)
+                // if it is initializing,  channel does not matter,  they all go to reliable channel
+                // otherwise,  only send the component if we are looking at the right channel.
+                // note that if we are spawning,  we expect all varibles to be dirty
+                if (comp.IsDirty() && (comp.GetNetworkChannel() == channelId || initialState))
                 {
                     // set bit #i to 1 in dirty mask
                     dirtyComponentsMask |= (ulong)(1L << i);

--- a/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
+++ b/Unity-Technologies-networking/Runtime/NetworkIdentity.cs
@@ -467,6 +467,10 @@ namespace UnityEngine.Networking
                     // set bit #i to 1 in dirty mask
                     dirtyComponentsMask |= (ulong)(1L << i);
 
+                    if (initialState)
+                    {
+                        comp.SetAllDirtyBits();
+                    }
                     // serialize and clear dirty bits in any case, since the component was clearly dirty if we got here
                     if (LogFilter.logDebug) { Debug.Log("OnSerializeAllSafely: " + name + " -> " + comp.GetType() + " initial=" + initialState + " channelId=" + channelId); }
                     OnSerializeSafely(comp, payload, initialState);

--- a/Unity-Technologies-networking/Weaver/UNetBehaviourProcessor.cs
+++ b/Unity-Technologies-networking/Weaver/UNetBehaviourProcessor.cs
@@ -514,7 +514,6 @@ namespace Unity.UNetWeaver
             serialize.Body.Variables.Add(dirtyLocal);
 
             // call base class
-            bool baseClassSerialize = false;
             if (m_td.BaseType.FullName != Weaver.NetworkBehaviourType.FullName)
             {
                 MethodReference baseSerialize = Weaver.ResolveMethod(m_td.BaseType, "OnSerialize");
@@ -525,7 +524,6 @@ namespace Unity.UNetWeaver
                     serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // forceAll
                     serWorker.Append(serWorker.Create(OpCodes.Call, baseSerialize));
                     serWorker.Append(serWorker.Create(OpCodes.Stloc_0)); // set dirtyLocal to result of base.OnSerialize()
-                    baseClassSerialize = true;
                 }
             }
 
@@ -538,39 +536,6 @@ namespace Unity.UNetWeaver
                 m_td.Methods.Add(serialize);
                 return;
             }
-
-            // Generates: if (forceAll);
-            Instruction initialStateLabel = serWorker.Create(OpCodes.Nop);
-            serWorker.Append(serWorker.Create(OpCodes.Ldarg_2)); // forceAll
-            serWorker.Append(serWorker.Create(OpCodes.Brfalse, initialStateLabel));
-
-            foreach (FieldDefinition syncVar in m_SyncVars)
-            {
-                // Generates a writer call for each sync variable
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_1)); // writer
-                serWorker.Append(serWorker.Create(OpCodes.Ldarg_0)); // this
-                serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar));
-                MethodReference writeFunc = Weaver.GetWriteFunc(syncVar.FieldType);
-                if (writeFunc != null)
-                {
-                    serWorker.Append(serWorker.Create(OpCodes.Call, writeFunc));
-                }
-                else
-                {
-                    Weaver.fail = true;
-                    Log.Error("GenerateSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. UNet [SyncVar] member variables must be basic types.");
-                    return;
-                }
-            }
-
-            // always return true if forceAll
-
-            // Generates: return true
-            serWorker.Append(serWorker.Create(OpCodes.Ldc_I4_1));
-            serWorker.Append(serWorker.Create(OpCodes.Ret));
-
-            // Generates: end if (forceAll);
-            serWorker.Append(initialStateLabel);
 
             // write dirty bits before the data fields
             // Generates: writer.WritePackedUInt64 (base.get_syncVarDirtyBits ());
@@ -868,61 +833,6 @@ namespace Unity.UNetWeaver
                 m_td.Methods.Add(serialize);
                 return;
             }
-
-            // Generates: if (initialState);
-            Instruction initialStateLabel = serWorker.Create(OpCodes.Nop);
-
-            serWorker.Append(serWorker.Create(OpCodes.Ldarg_2));
-            serWorker.Append(serWorker.Create(OpCodes.Brfalse, initialStateLabel));
-
-            foreach (var syncVar in m_SyncVars)
-            {
-                MethodReference readByReferenceFunc = Weaver.GetReadByReferenceFunc(syncVar.FieldType);
-                if (readByReferenceFunc != null)
-                {
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
-                    serWorker.Append(serWorker.Create(OpCodes.Ldfld, syncVar));
-                    serWorker.Append(serWorker.Create(OpCodes.Call, readByReferenceFunc));
-                }
-                else
-                {
-                    // assign value
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_0));
-                    serWorker.Append(serWorker.Create(OpCodes.Ldarg_1));
-
-                    if (syncVar.FieldType.FullName == Weaver.gameObjectType.FullName)
-                    {
-                        // GameObject SyncVar - assign to generated netId var
-                        FieldDefinition netIdField = m_SyncVarNetIds[m_NetIdFieldCounter];
-                        m_NetIdFieldCounter += 1;
-
-                        serWorker.Append(serWorker.Create(OpCodes.Callvirt, Weaver.NetworkReaderReadNetworkInstanceId));
-                        serWorker.Append(serWorker.Create(OpCodes.Stfld, netIdField));
-                    }
-                    else
-                    {
-                        MethodReference readFunc = Weaver.GetReadFunc(syncVar.FieldType);
-                        if (readFunc != null)
-                        {
-                            serWorker.Append(serWorker.Create(OpCodes.Call, readFunc));
-                        }
-                        else
-                        {
-                            Log.Error("GenerateDeSerialization for " + m_td.Name + " unknown type [" + syncVar.FieldType + "]. UNet [SyncVar] member variables must be basic types.");
-                            Weaver.fail = true;
-                            return;
-                        }
-                        serWorker.Append(serWorker.Create(OpCodes.Stfld, syncVar));
-                    }
-                }
-            }
-
-            serWorker.Append(serWorker.Create(OpCodes.Ret));
-
-            // Generates: end if (initialState);
-            serWorker.Append(initialStateLabel);
-
 
             // setup local for dirty bits
             serialize.Body.InitLocals = true;


### PR DESCRIPTION
Variables with the attribute:
```
[SyncVar(target = SyncTarget.Owner)]
```

will only be synchronized with the client with authority. This is useful for inventory and other data that doesn't need to be visible to other players.

Here is a full example:
```
public class SampleBehavior : NetworkBehaviour {

    [SyncVar]
    public int myVariable;

    [SyncVar(target = SyncTarget.Owner)]
    public string myData2;

    [SyncVar(target = SyncTarget.Owner)]
    public SyncListInt myOwnerList;
}
```

