### PR TITLE
Update the README file to reflect the location of the Linux DLLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,15 @@ Backup the original DLL files from your Unity installation folder and replace th
 
 Note: right click Unity.app and select 'Show Package Contents' to see the subfolders.
 ## Linux:
-You'll find it  
-(feel free to submit a pull request for filling this part)
+*NOTE:* This assumes Assuming you installed the experimental Unity build in your home directory at, let's say `/home/user/Unity` (the default usually is Unity followed by the version, ie. 2017.4.8). This was also tested on a version of the Ubuntu-based KDE Neon distro.
+1. *Backup your Project! Be wise now and don't lose everything if something unexpected happens.* Unity is experimental on Linux and **THIS COULD SPELL DOOM FOR YOUR PROJECT** if the Editor breaks in half. (Probably not, though.)
+2. The `Editor` and `Standalone` folders go into `/home/user/Unity/Editor/Data/UnityExtensions/Unity/Networking`. If prompted for overwrite, allow the overwrite.
+3. If you do not have this directory path, *STOP*. Submit a support request and we'll try to help you out.
+4. Copy `Unity.UNetWeaver.dll` into `/home/user/Unity/Editor/Data/Managed`.
+5. (Re-)Start Unity to make sure the changes are applied. Be patient while Unity recompiles your network scripts for use with the latest version of HLAPI CE.
+6. If you got no critical/fatal errors from Unity itself then *congratulations*. If you get errors from your scripts, it's likely due to stuff that got stripped out in the improvements branch. Consider updating your code.
+7. Again, it should be noted that Unity on Linux is very experimental and likely to blow up at any given moment. While it does work, we cannot vouch for its stability on the Linux platform.
+8. Rebuild your server and client builds to properly use the features and improvements in HLAPI CE.
 
 # Branches:
 


### PR DESCRIPTION
This basically adds instructions on how to actually use HLAPI CE with Linux Unity editor.

Someone was lazy when they wrote the README file so I looked in the Linux partition on my hard disk and located and documented their path.

Should be 99% error-free. Any errors probably will be user error.